### PR TITLE
Add multi-page layout with service cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@mui/icons-material": "^7.2.0",
         "@mui/material": "^7.2.0",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.7.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -2040,6 +2041,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -3099,6 +3109,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.7.1.tgz",
+      "integrity": "sha512-jVKHXoWRIsD/qS6lvGveckwb862EekvapdHJN/cGmzw40KnJH5gg53ujOJ4qX6EKIK9LSBfFed/xiQ5yeXNrUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.7.1.tgz",
+      "integrity": "sha512-bavdk2BA5r3MYalGKZ01u8PGuDBloQmzpBZVhDLrOOv1N943Wq6dcM9GhB3x8b7AbqPMEezauv4PeGkAJfy7FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.7.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -3199,6 +3247,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "@mui/icons-material": "^7.2.0",
     "@mui/material": "^7.2.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.7.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,179 +3,59 @@ import {
   AppBar,
   Toolbar,
   Typography,
-  Container,
   Box,
-  List,
-  ListItem,
-  ListItemText,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
-  Paper,
-  TableContainer,
+  Button,
 } from '@mui/material'
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
+import Home from './pages/Home.jsx'
+import Software from './pages/Software.jsx'
+import Research from './pages/Research.jsx'
+import Video from './pages/Video.jsx'
+import AppDev from './pages/AppDev.jsx'
 
 function App() {
   return (
-    <>
+    <BrowserRouter>
       <AppBar position="static">
         <Toolbar>
-          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+          <Typography
+            variant="h6"
+            component={Link}
+            to="/"
+            sx={{ flexGrow: 1, color: 'inherit', textDecoration: 'none' }}
+          >
             YashubuStudio
           </Typography>
-          <Typography variant="body1">最新技術を、もっと身近に、もっと確実に。</Typography>
+          <Button color="inherit" component={Link} to="/software">
+            ソフトウェア開発
+          </Button>
+          <Button color="inherit" component={Link} to="/research">
+            システム研究
+          </Button>
+          <Button color="inherit" component={Link} to="/video">
+            動画配信
+          </Button>
+          <Button color="inherit" component={Link} to="/appdev">
+            アプリ開発
+          </Button>
         </Toolbar>
       </AppBar>
-      <Container component="main" sx={{ py: 4 }}>
-        <Box component="section" id="overview" sx={{ mb: 4 }}>
-          <Typography variant="h4" component="h2" gutterBottom>
-            概要
-          </Typography>
-          <Typography paragraph>
-            YashubuStudioは日本・愛知県を拠点に活動するテクノロジー系スタジオです。
-            システム開発、Web制作、AI・自動化、動画配信まで幅広く対応し、個人事業主から
-            中小企業までのデジタルニーズにお応えします。
-          </Typography>
-        </Box>
 
-        <Box component="section" id="services" sx={{ mb: 4 }}>
-          <Typography variant="h4" component="h2" gutterBottom>
-            主な事業内容
-          </Typography>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/software" element={<Software />} />
+        <Route path="/research" element={<Research />} />
+        <Route path="/video" element={<Video />} />
+        <Route path="/appdev" element={<AppDev />} />
+      </Routes>
 
-          <Typography variant="h5" component="h3" gutterBottom>
-            ソフトウェア開発・Web制作
-          </Typography>
-          <List dense>
-            <ListItem><ListItemText primary="業務支援アプリケーションの開発" /></ListItem>
-            <ListItem><ListItemText primary="オンライン申請や社内検索など日常業務を支えるシステム" /></ListItem>
-            <ListItem><ListItemText primary="CMSや動的UIにも対応" /></ListItem>
-            <ListItem><ListItemText primary="静的ページからReactによるSPAまで幅広く対応" /></ListItem>
-          </List>
-
-          <Typography variant="h5" component="h3" gutterBottom sx={{ mt: 2 }}>
-            システム研究・開発
-          </Typography>
-          <List dense>
-            <ListItem><ListItemText primary="検索エンジン、AI連携、P2P分散ネットワークの研究開発" /></ListItem>
-            <ListItem><ListItemText primary="意味圧縮・全文検索・ノード構成の自動最適化" /></ListItem>
-            <ListItem><ListItemText primary="実験的プロトタイピング支援" /></ListItem>
-          </List>
-
-          <Typography variant="h5" component="h3" gutterBottom sx={{ mt: 2 }}>
-            動画配信・撮影・編集
-          </Typography>
-          <List dense>
-            <ListItem><ListItemText primary="ライブ配信や録画収録のサポート" /></ListItem>
-            <ListItem><ListItemText primary="セミナー・講演会・社内研修など現場での撮影支援" /></ListItem>
-            <ListItem><ListItemText primary="動画編集は規模により要相談" /></ListItem>
-          </List>
-
-          <Typography variant="h5" component="h3" gutterBottom sx={{ mt: 2 }}>
-            アプリ開発
-          </Typography>
-          <List dense>
-            <ListItem><ListItemText primary="Webアプリからモバイルアプリまでマルチプラットフォーム対応" /></ListItem>
-            <ListItem><ListItemText primary="要件定義からクラウド連携まで一貫支援" /></ListItem>
-            <ListItem><ListItemText primary="PWA化やリアルタイムデータ表示にも対応" /></ListItem>
-          </List>
-        </Box>
-
-        <Box component="section" id="clients" sx={{ mb: 4 }}>
-          <Typography variant="h4" component="h2" gutterBottom>
-            対象のお客様
-          </Typography>
-          <List dense>
-            <ListItem><ListItemText primary="フリーランス・講師・YouTuber 等の個人事業主の方" /></ListItem>
-            <ListItem><ListItemText primary="1〜50人規模の小規模法人や店舗事業者の方" /></ListItem>
-            <ListItem><ListItemText primary="システム部門を持たない中小企業の事業者様" /></ListItem>
-          </List>
-        </Box>
-
-        <Box component="section" id="strengths" sx={{ mb: 4 }}>
-          <Typography variant="h4" component="h2" gutterBottom>
-            YashubuStudioの強み
-          </Typography>
-          <List dense>
-            <ListItem><ListItemText primary="本質的な課題を読み取るヒアリング力" /></ListItem>
-            <ListItem><ListItemText primary="曖昧な仕様でも形にする技術設計力" /></ListItem>
-            <ListItem><ListItemText primary="少人数・小予算でも運用できる品質" /></ListItem>
-            <ListItem><ListItemText primary="開発後の継続的な相談・アップデートも対応" /></ListItem>
-          </List>
-        </Box>
-
-        <Box component="section" id="pricing" sx={{ mb: 4 }}>
-          <Typography variant="h4" component="h2" gutterBottom>
-            料金の目安（すべて要相談）
-          </Typography>
-          <TableContainer component={Paper} sx={{ mb: 2 }}>
-            <Table size="small">
-              <TableHead>
-                <TableRow>
-                  <TableCell>サービス</TableCell>
-                  <TableCell>概算価格（税込）</TableCell>
-                  <TableCell>備考</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                <TableRow>
-                  <TableCell>Web制作</TableCell>
-                  <TableCell>¥30,000～</TableCell>
-                  <TableCell>ランディングページ～CMS対応まで</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell>システム開発</TableCell>
-                  <TableCell>¥100,000～</TableCell>
-                  <TableCell>業務支援・管理系・API連携等</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell>動画配信（撮影含む）</TableCell>
-                  <TableCell>¥20,000～</TableCell>
-                  <TableCell>配信支援・マルチカメラも対応可能</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell>アプリ開発</TableCell>
-                  <TableCell>¥500,000～</TableCell>
-                  <TableCell>要件により大きく変動</TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
-          </TableContainer>
-          <Typography variant="body2">※価格は目安であり、内容・期間・規模により都度見積を行います。</Typography>
-        </Box>
-
-        <Box component="section" id="tech" sx={{ mb: 4 }}>
-          <Typography variant="h4" component="h2" gutterBottom>
-            対応技術・プログラミング言語
-          </Typography>
-          <List dense>
-            <ListItem><ListItemText primary="バックエンド: Go / Python / Node.js / PHP / Java / Basic / C / C++" /></ListItem>
-            <ListItem><ListItemText primary="フロントエンド: React / HTML / CSS / JavaScript" /></ListItem>
-            <ListItem><ListItemText primary="その他: SQL / Shell / OBS連携 / SQLite / JSON API / REST API 等" /></ListItem>
-          </List>
-        </Box>
-
-        <Box component="section" id="contact" sx={{ mb: 4 }}>
-          <Typography variant="h4" component="h2" gutterBottom>
-            お問い合わせ・ご相談
-          </Typography>
-          <Typography>メール: <a href="mailto:info@ykvario.com">info@ykvario.com</a></Typography>
-          <Typography>電話: 080-6192-0581</Typography>
-          <Typography>営業時間: 7:00〜21:00（月～土）</Typography>
-          <Typography>
-            Webサイト: <a href="https://ykvario.com" target="_blank" rel="noopener noreferrer">https://ykvario.com</a>
-          </Typography>
-        </Box>
-      </Container>
       <Box
         component="footer"
         sx={{ bgcolor: 'primary.main', color: 'primary.contrastText', textAlign: 'center', py: 2 }}
       >
         <Typography variant="body2">&copy; 2024 YashubuStudio</Typography>
       </Box>
-    </>
+    </BrowserRouter>
   )
 }
 

--- a/src/pages/AppDev.jsx
+++ b/src/pages/AppDev.jsx
@@ -1,0 +1,12 @@
+import { Container, Typography } from '@mui/material'
+
+export default function AppDev() {
+  return (
+    <Container sx={{ py: 4 }}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        アプリ開発
+      </Typography>
+      <Typography>このページではアプリ開発の詳細を説明します。</Typography>
+    </Container>
+  )
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,50 @@
+import {
+  Box,
+  Container,
+  Typography,
+  Grid,
+  Card,
+  CardContent,
+  CardActionArea,
+} from '@mui/material'
+import { Link } from 'react-router-dom'
+
+const services = [
+  { title: 'ソフトウェア開発・Web制作', path: '/software' },
+  { title: 'システム研究・開発', path: '/research' },
+  { title: '動画配信・撮影・編集', path: '/video' },
+  { title: 'アプリ開発', path: '/appdev' },
+]
+
+export default function Home() {
+  return (
+    <>
+      <Box sx={{ bgcolor: 'primary.main', color: 'primary.contrastText', py: 6, textAlign: 'center' }}>
+        <Typography variant="h3" component="h1">
+          YashubuStudio
+        </Typography>
+        <Typography variant="h6">最新技術を、もっと身近に、もっと確実に。</Typography>
+      </Box>
+      <Container sx={{ py: 4 }}>
+        <Typography variant="h4" component="h2" gutterBottom>
+          対応可能な業務内容
+        </Typography>
+        <Grid container spacing={2}>
+          {services.map((s) => (
+            <Grid item xs={12} sm={6} md={3} key={s.path}>
+              <Card>
+                <CardActionArea component={Link} to={s.path} sx={{ height: '100%' }}>
+                  <CardContent>
+                    <Typography variant="h6" component="div">
+                      {s.title}
+                    </Typography>
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            </Grid>
+          ))}
+        </Grid>
+      </Container>
+    </>
+  )
+}

--- a/src/pages/Research.jsx
+++ b/src/pages/Research.jsx
@@ -1,0 +1,12 @@
+import { Container, Typography } from '@mui/material'
+
+export default function Research() {
+  return (
+    <Container sx={{ py: 4 }}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        システム研究・開発
+      </Typography>
+      <Typography>このページではシステム研究・開発の詳細を説明します。</Typography>
+    </Container>
+  )
+}

--- a/src/pages/Software.jsx
+++ b/src/pages/Software.jsx
@@ -1,0 +1,12 @@
+import { Container, Typography } from '@mui/material'
+
+export default function Software() {
+  return (
+    <Container sx={{ py: 4 }}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        ソフトウェア開発・Web制作
+      </Typography>
+      <Typography>このページではソフトウェア開発・Web制作の詳細を説明します。</Typography>
+    </Container>
+  )
+}

--- a/src/pages/Video.jsx
+++ b/src/pages/Video.jsx
@@ -1,0 +1,12 @@
+import { Container, Typography } from '@mui/material'
+
+export default function Video() {
+  return (
+    <Container sx={{ py: 4 }}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        動画配信・撮影・編集
+      </Typography>
+      <Typography>このページでは動画配信・撮影・編集の詳細を説明します。</Typography>
+    </Container>
+  )
+}


### PR DESCRIPTION
## Summary
- add `react-router-dom` dependency
- switch `App` to use router and navigation buttons
- create `Home` page with service cards
- add placeholder pages for each service

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c2cf3ef9083239062e1b376ab70d6