### PR TITLE
Enhance service pages with descriptions

### DIFF
--- a/src/pages/AppDev.jsx
+++ b/src/pages/AppDev.jsx
@@ -1,12 +1,24 @@
 import { Container, Typography } from '@mui/material'
 
+const items = [
+  'Webアプリからモバイルアプリまでマルチプラットフォームに対応',
+  '要件定義・画面設計・バックエンド実装・クラウド連携を一貫支援',
+  'PWA化や非同期処理、リアルタイムデータ表示などにも対応',
+]
+
 export default function AppDev() {
   return (
     <Container sx={{ py: 4 }}>
       <Typography variant="h4" component="h1" gutterBottom>
         アプリ開発
       </Typography>
-      <Typography>このページではアプリ開発の詳細を説明します。</Typography>
+      <ul>
+        {items.map((text) => (
+          <li key={text}>
+            <Typography component="span">{text}</Typography>
+          </li>
+        ))}
+      </ul>
     </Container>
   )
 }

--- a/src/pages/Research.jsx
+++ b/src/pages/Research.jsx
@@ -1,12 +1,24 @@
 import { Container, Typography } from '@mui/material'
 
+const items = [
+  '検索エンジン、AI連携、P2P分散ネットワークなどの研究開発',
+  '意味圧縮・全文検索・ノード構成の自動最適化といった応用分野に注力',
+  '実験的・検証的なプロトタイピング支援も対応可能',
+]
+
 export default function Research() {
   return (
     <Container sx={{ py: 4 }}>
       <Typography variant="h4" component="h1" gutterBottom>
         システム研究・開発
       </Typography>
-      <Typography>このページではシステム研究・開発の詳細を説明します。</Typography>
+      <ul>
+        {items.map((text) => (
+          <li key={text}>
+            <Typography component="span">{text}</Typography>
+          </li>
+        ))}
+      </ul>
     </Container>
   )
 }

--- a/src/pages/Software.jsx
+++ b/src/pages/Software.jsx
@@ -1,12 +1,25 @@
 import { Container, Typography } from '@mui/material'
 
+const items = [
+  '社内業務の効率化を目的とした業務支援アプリケーションの開発',
+  'オンライン申請や社内検索、帳票出力など日常業務を支えるシステム',
+  '管理画面やホームページなどCMSや動的UIにも対応',
+  '静的なHTML/CSSページからReactによるSPAまで幅広く対応',
+]
+
 export default function Software() {
   return (
     <Container sx={{ py: 4 }}>
       <Typography variant="h4" component="h1" gutterBottom>
         ソフトウェア開発・Web制作
       </Typography>
-      <Typography>このページではソフトウェア開発・Web制作の詳細を説明します。</Typography>
+      <ul>
+        {items.map((text) => (
+          <li key={text}>
+            <Typography component="span">{text}</Typography>
+          </li>
+        ))}
+      </ul>
     </Container>
   )
 }

--- a/src/pages/Video.jsx
+++ b/src/pages/Video.jsx
@@ -1,12 +1,25 @@
 import { Container, Typography } from '@mui/material'
 
+const items = [
+  'ライブ配信や録画収録のサポート (YouTube Live / OBS / Zoom 等)',
+  'セミナー・講演会・社内研修など現場での撮影・技術支援に対応',
+  '三脚・カメラ・マイク・照明など基本的な機材を一通り所持',
+  '動画編集も可能だが内容により要相談',
+]
+
 export default function Video() {
   return (
     <Container sx={{ py: 4 }}>
       <Typography variant="h4" component="h1" gutterBottom>
         動画配信・撮影・編集
       </Typography>
-      <Typography>このページでは動画配信・撮影・編集の詳細を説明します。</Typography>
+      <ul>
+        {items.map((text) => (
+          <li key={text}>
+            <Typography component="span">{text}</Typography>
+          </li>
+        ))}
+      </ul>
     </Container>
   )
 }


### PR DESCRIPTION
## Summary
- update service pages (Software, Research, Video, AppDev) with bullet lists describing each offering

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c2fd341a0832397ca1dd29a8ae414