### PR TITLE
Refactor header/footer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,5 @@
 import './App.css'
-import {
-  AppBar,
-  Toolbar,
-  Typography,
-  Box,
-  Button,
-} from '@mui/material'
-import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import Home from './pages/Home.jsx'
 import Software from './pages/Software.jsx'
 import Research from './pages/Research.jsx'
@@ -16,31 +9,6 @@ import AppDev from './pages/AppDev.jsx'
 function App() {
   return (
     <BrowserRouter>
-      <AppBar position="static">
-        <Toolbar>
-          <Typography
-            variant="h6"
-            component={Link}
-            to="/"
-            sx={{ flexGrow: 1, color: 'inherit', textDecoration: 'none' }}
-          >
-            YashubuStudio
-          </Typography>
-          <Button color="inherit" component={Link} to="/software">
-            ソフトウェア開発
-          </Button>
-          <Button color="inherit" component={Link} to="/research">
-            システム研究
-          </Button>
-          <Button color="inherit" component={Link} to="/video">
-            動画配信
-          </Button>
-          <Button color="inherit" component={Link} to="/appdev">
-            アプリ開発
-          </Button>
-        </Toolbar>
-      </AppBar>
-
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/software" element={<Software />} />
@@ -48,13 +16,6 @@ function App() {
         <Route path="/video" element={<Video />} />
         <Route path="/appdev" element={<AppDev />} />
       </Routes>
-
-      <Box
-        component="footer"
-        sx={{ bgcolor: 'primary.main', color: 'primary.contrastText', textAlign: 'center', py: 2 }}
-      >
-        <Typography variant="body2">&copy; 2024 YashubuStudio</Typography>
-      </Box>
     </BrowserRouter>
   )
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,12 @@
+import { Box, Typography } from '@mui/material'
+
+export default function Footer() {
+  return (
+    <Box
+      component="footer"
+      sx={{ bgcolor: 'primary.main', color: 'primary.contrastText', textAlign: 'center', py: 2 }}
+    >
+      <Typography variant="body2">&copy; 2024 YashubuStudio</Typography>
+    </Box>
+  )
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,31 @@
+import { AppBar, Toolbar, Typography, Button } from '@mui/material'
+import { Link } from 'react-router-dom'
+
+export default function Header() {
+  return (
+    <AppBar position="static">
+      <Toolbar>
+        <Typography
+          variant="h6"
+          component={Link}
+          to="/"
+          sx={{ flexGrow: 1, color: 'inherit', textDecoration: 'none' }}
+        >
+          YashubuStudio
+        </Typography>
+        <Button color="inherit" component={Link} to="/software">
+          ソフトウェア開発
+        </Button>
+        <Button color="inherit" component={Link} to="/research">
+          システム研究
+        </Button>
+        <Button color="inherit" component={Link} to="/video">
+          動画配信
+        </Button>
+        <Button color="inherit" component={Link} to="/appdev">
+          アプリ開発
+        </Button>
+      </Toolbar>
+    </AppBar>
+  )
+}

--- a/src/pages/AppDev.jsx
+++ b/src/pages/AppDev.jsx
@@ -1,4 +1,6 @@
 import { Container, Typography } from '@mui/material'
+import Header from '../components/Header.jsx'
+import Footer from '../components/Footer.jsx'
 
 const items = [
   'Webアプリからモバイルアプリまでマルチプラットフォームに対応',
@@ -8,17 +10,21 @@ const items = [
 
 export default function AppDev() {
   return (
-    <Container sx={{ py: 4 }}>
-      <Typography variant="h4" component="h1" gutterBottom>
-        アプリ開発
-      </Typography>
-      <ul>
-        {items.map((text) => (
-          <li key={text}>
-            <Typography component="span">{text}</Typography>
-          </li>
-        ))}
-      </ul>
-    </Container>
+    <>
+      <Header />
+      <Container sx={{ py: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          アプリ開発
+        </Typography>
+        <ul>
+          {items.map((text) => (
+            <li key={text}>
+              <Typography component="span">{text}</Typography>
+            </li>
+          ))}
+        </ul>
+      </Container>
+      <Footer />
+    </>
   )
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -8,6 +8,8 @@ import {
   CardActionArea,
 } from '@mui/material'
 import { Link } from 'react-router-dom'
+import Header from '../components/Header.jsx'
+import Footer from '../components/Footer.jsx'
 
 const services = [
   { title: 'ソフトウェア開発・Web制作', path: '/software' },
@@ -19,6 +21,7 @@ const services = [
 export default function Home() {
   return (
     <>
+      <Header />
       <Box sx={{ bgcolor: 'primary.main', color: 'primary.contrastText', py: 6, textAlign: 'center' }}>
         <Typography variant="h3" component="h1">
           YashubuStudio
@@ -45,6 +48,7 @@ export default function Home() {
           ))}
         </Grid>
       </Container>
+      <Footer />
     </>
   )
 }

--- a/src/pages/Research.jsx
+++ b/src/pages/Research.jsx
@@ -1,4 +1,6 @@
 import { Container, Typography } from '@mui/material'
+import Header from '../components/Header.jsx'
+import Footer from '../components/Footer.jsx'
 
 const items = [
   '検索エンジン、AI連携、P2P分散ネットワークなどの研究開発',
@@ -8,17 +10,21 @@ const items = [
 
 export default function Research() {
   return (
-    <Container sx={{ py: 4 }}>
-      <Typography variant="h4" component="h1" gutterBottom>
-        システム研究・開発
-      </Typography>
-      <ul>
-        {items.map((text) => (
-          <li key={text}>
-            <Typography component="span">{text}</Typography>
-          </li>
-        ))}
-      </ul>
-    </Container>
+    <>
+      <Header />
+      <Container sx={{ py: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          システム研究・開発
+        </Typography>
+        <ul>
+          {items.map((text) => (
+            <li key={text}>
+              <Typography component="span">{text}</Typography>
+            </li>
+          ))}
+        </ul>
+      </Container>
+      <Footer />
+    </>
   )
 }

--- a/src/pages/Software.jsx
+++ b/src/pages/Software.jsx
@@ -1,4 +1,6 @@
 import { Container, Typography } from '@mui/material'
+import Header from '../components/Header.jsx'
+import Footer from '../components/Footer.jsx'
 
 const items = [
   '社内業務の効率化を目的とした業務支援アプリケーションの開発',
@@ -9,17 +11,21 @@ const items = [
 
 export default function Software() {
   return (
-    <Container sx={{ py: 4 }}>
-      <Typography variant="h4" component="h1" gutterBottom>
-        ソフトウェア開発・Web制作
-      </Typography>
-      <ul>
-        {items.map((text) => (
-          <li key={text}>
-            <Typography component="span">{text}</Typography>
-          </li>
-        ))}
-      </ul>
-    </Container>
+    <>
+      <Header />
+      <Container sx={{ py: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          ソフトウェア開発・Web制作
+        </Typography>
+        <ul>
+          {items.map((text) => (
+            <li key={text}>
+              <Typography component="span">{text}</Typography>
+            </li>
+          ))}
+        </ul>
+      </Container>
+      <Footer />
+    </>
   )
 }

--- a/src/pages/Video.jsx
+++ b/src/pages/Video.jsx
@@ -1,4 +1,6 @@
 import { Container, Typography } from '@mui/material'
+import Header from '../components/Header.jsx'
+import Footer from '../components/Footer.jsx'
 
 const items = [
   'ライブ配信や録画収録のサポート (YouTube Live / OBS / Zoom 等)',
@@ -9,17 +11,21 @@ const items = [
 
 export default function Video() {
   return (
-    <Container sx={{ py: 4 }}>
-      <Typography variant="h4" component="h1" gutterBottom>
-        動画配信・撮影・編集
-      </Typography>
-      <ul>
-        {items.map((text) => (
-          <li key={text}>
-            <Typography component="span">{text}</Typography>
-          </li>
-        ))}
-      </ul>
-    </Container>
+    <>
+      <Header />
+      <Container sx={{ py: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          動画配信・撮影・編集
+        </Typography>
+        <ul>
+          {items.map((text) => (
+            <li key={text}>
+              <Typography component="span">{text}</Typography>
+            </li>
+          ))}
+        </ul>
+      </Container>
+      <Footer />
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- extract header and footer into new components
- use header and footer components within each page
- simplify `App.jsx` so it only handles routing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c329f042483239c0e466c48610627