### PR TITLE
Improve homepage and add contact

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,8 @@ import Software from './pages/Software.jsx'
 import Research from './pages/Research.jsx'
 import Video from './pages/Video.jsx'
 import AppDev from './pages/AppDev.jsx'
+import Contact from './pages/Contact.jsx'
+import Flow from './pages/Flow.jsx'
 
 function App() {
   return (
@@ -15,6 +17,8 @@ function App() {
         <Route path="/research" element={<Research />} />
         <Route path="/video" element={<Video />} />
         <Route path="/appdev" element={<AppDev />} />
+        <Route path="/flow" element={<Flow />} />
+        <Route path="/contact" element={<Contact />} />
       </Routes>
     </BrowserRouter>
   )

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -25,6 +25,12 @@ export default function Header() {
         <Button color="inherit" component={Link} to="/appdev">
           アプリ開発
         </Button>
+        <Button color="inherit" component={Link} to="/flow">
+          納品までの流れ
+        </Button>
+        <Button color="inherit" component={Link} to="/contact">
+          お問い合わせ
+        </Button>
       </Toolbar>
     </AppBar>
   )

--- a/src/contactFormURL.js
+++ b/src/contactFormURL.js
@@ -1,0 +1,1 @@
+export const CONTACT_FORM_URL = 'https://forms.gle/your-form-url';

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,0 +1,31 @@
+import { Container, Typography, Button } from '@mui/material'
+import Header from '../components/Header.jsx'
+import Footer from '../components/Footer.jsx'
+import { CONTACT_FORM_URL } from '../contactFormURL.js'
+
+export default function Contact() {
+  return (
+    <>
+      <Header />
+      <Container sx={{ py: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          お問い合わせ
+        </Typography>
+        <Typography sx={{ mb: 2 }}>
+          下記のフォームからお気軽にご連絡ください。
+        </Typography>
+        <iframe
+          title="contact form"
+          src={CONTACT_FORM_URL}
+          width="100%"
+          height="600"
+          style={{ border: 0 }}
+        />
+        <Button variant="contained" color="primary" href={CONTACT_FORM_URL} sx={{ mt: 2 }}>
+          フォームを開く
+        </Button>
+      </Container>
+      <Footer />
+    </>
+  )
+}

--- a/src/pages/Flow.jsx
+++ b/src/pages/Flow.jsx
@@ -1,0 +1,33 @@
+import { Container, Typography } from '@mui/material'
+import Header from '../components/Header.jsx'
+import Footer from '../components/Footer.jsx'
+
+const steps = [
+  'お問い合わせ',
+  'ヒアリング・要件整理',
+  'お見積り',
+  '契約・開発開始',
+  '確認・修正',
+  '納品・サポート'
+]
+
+export default function Flow() {
+  return (
+    <>
+      <Header />
+      <Container sx={{ py: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          納品までの流れ
+        </Typography>
+        <ol>
+          {steps.map((s) => (
+            <li key={s}>
+              <Typography component="span">{s}</Typography>
+            </li>
+          ))}
+        </ol>
+      </Container>
+      <Footer />
+    </>
+  )
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -12,10 +12,26 @@ import Header from '../components/Header.jsx'
 import Footer from '../components/Footer.jsx'
 
 const services = [
-  { title: 'ソフトウェア開発・Web制作', path: '/software' },
-  { title: 'システム研究・開発', path: '/research' },
-  { title: '動画配信・撮影・編集', path: '/video' },
-  { title: 'アプリ開発', path: '/appdev' },
+  {
+    title: 'ソフトウェア開発・Web制作',
+    path: '/software',
+    desc: '業務支援アプリやホームページ制作などをトータルで対応'
+  },
+  {
+    title: 'システム研究・開発',
+    path: '/research',
+    desc: 'AI連携や分散技術を活用した高度なシステム開発'
+  },
+  {
+    title: '動画配信・撮影・編集',
+    path: '/video',
+    desc: '配信・撮影から編集までワンストップでサポート'
+  },
+  {
+    title: 'アプリ開発',
+    path: '/appdev',
+    desc: 'Webからモバイルまでマルチプラットフォームに対応'
+  },
 ]
 
 export default function Home() {
@@ -29,17 +45,28 @@ export default function Home() {
         <Typography variant="h6">最新技術を、もっと身近に、もっと確実に。</Typography>
       </Box>
       <Container sx={{ py: 4 }}>
+        <Typography variant="h5" gutterBottom>
+          実際の例・イメージ
+        </Typography>
+        <Box sx={{ bgcolor: 'grey.200', p: 4, textAlign: 'center', mb: 4 }}>
+          <Typography>(ここに事例の画像が入ります)</Typography>
+        </Box>
+      </Container>
+      <Container sx={{ py: 4 }}>
         <Typography variant="h4" component="h2" gutterBottom>
-          対応可能な業務内容
+          サービス内容
         </Typography>
         <Grid container spacing={2}>
           {services.map((s) => (
             <Grid item xs={12} sm={6} md={3} key={s.path}>
               <Card>
                 <CardActionArea component={Link} to={s.path} sx={{ height: '100%' }}>
-                  <CardContent>
-                    <Typography variant="h6" component="div">
+                  <CardContent sx={{ textAlign: 'center' }}>
+                    <Typography variant="h6" component="div" gutterBottom>
                       {s.title}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {s.desc}
                     </Typography>
                   </CardContent>
                 </CardActionArea>


### PR DESCRIPTION
## Summary
- show placeholder example on the top page
- change service heading text and add short descriptions
- center card text
- add navigation links for flow and contact
- add contact form and flow pages

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688c390922d8832391d558db22a59447