### PR TITLE
Implement services dropdown and responsive menu

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import Software from './pages/Software.jsx'
 import Research from './pages/Research.jsx'
 import Video from './pages/Video.jsx'
 import AppDev from './pages/AppDev.jsx'
+import Services from './pages/Services.jsx'
 import Contact from './pages/Contact.jsx'
 import Flow from './pages/Flow.jsx'
 
@@ -13,6 +14,7 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Home />} />
+        <Route path="/services" element={<Services />} />
         <Route path="/software" element={<Software />} />
         <Route path="/research" element={<Research />} />
         <Route path="/video" element={<Video />} />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,7 +1,53 @@
-import { AppBar, Toolbar, Typography, Button } from '@mui/material'
+import { useState } from 'react'
+import {
+  AppBar,
+  Toolbar,
+  Typography,
+  Button,
+  Menu,
+  MenuItem,
+  IconButton,
+  Drawer,
+  List,
+  ListItem,
+  ListItemText,
+  Box,
+  useTheme,
+  useMediaQuery
+} from '@mui/material'
+import MenuIcon from '@mui/icons-material/Menu'
 import { Link } from 'react-router-dom'
 
+const serviceLinks = [
+  { label: 'ソフトウェア開発', path: '/software' },
+  { label: 'システム研究', path: '/research' },
+  { label: '動画配信', path: '/video' },
+  { label: 'アプリ開発', path: '/appdev' }
+]
+
+const otherLinks = [
+  { label: '納品までの流れ', path: '/flow' },
+  { label: 'お問い合わせ', path: '/contact' }
+]
+
 export default function Header() {
+  const [anchorEl, setAnchorEl] = useState(null)
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
+
+  const handleMenuOpen = (event) => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handleMenuClose = () => {
+    setAnchorEl(null)
+  }
+
+  const toggleDrawer = (open) => () => {
+    setDrawerOpen(open)
+  }
+
   return (
     <AppBar position="static">
       <Toolbar>
@@ -13,24 +59,67 @@ export default function Header() {
         >
           YashubuStudio
         </Typography>
-        <Button color="inherit" component={Link} to="/software">
-          ソフトウェア開発
-        </Button>
-        <Button color="inherit" component={Link} to="/research">
-          システム研究
-        </Button>
-        <Button color="inherit" component={Link} to="/video">
-          動画配信
-        </Button>
-        <Button color="inherit" component={Link} to="/appdev">
-          アプリ開発
-        </Button>
-        <Button color="inherit" component={Link} to="/flow">
-          納品までの流れ
-        </Button>
-        <Button color="inherit" component={Link} to="/contact">
-          お問い合わせ
-        </Button>
+        {isMobile ? (
+          <>
+            <IconButton color="inherit" edge="end" onClick={toggleDrawer(true)}>
+              <MenuIcon />
+            </IconButton>
+            <Drawer anchor="right" open={drawerOpen} onClose={toggleDrawer(false)}>
+              <Box sx={{ width: 250 }} role="presentation" onClick={toggleDrawer(false)}>
+                <List>
+                  <ListItem button component={Link} to="/services">
+                    <ListItemText primary="サービス内容" />
+                  </ListItem>
+                  {serviceLinks.map((s) => (
+                    <ListItem button key={s.path} component={Link} to={s.path}>
+                      <ListItemText primary={s.label} />
+                    </ListItem>
+                  ))}
+                  {otherLinks.map((o) => (
+                    <ListItem button key={o.path} component={Link} to={o.path}>
+                      <ListItemText primary={o.label} />
+                    </ListItem>
+                  ))}
+                </List>
+              </Box>
+            </Drawer>
+          </>
+        ) : (
+          <>
+            <Button
+              color="inherit"
+              onMouseEnter={handleMenuOpen}
+              onClick={handleMenuOpen}
+              component={Link}
+              to="/services"
+              sx={{ mr: 1 }}
+            >
+              サービス内容
+            </Button>
+            <Menu
+              anchorEl={anchorEl}
+              open={Boolean(anchorEl)}
+              onClose={handleMenuClose}
+              MenuListProps={{ onMouseLeave: handleMenuClose }}
+            >
+              {serviceLinks.map((s) => (
+                <MenuItem
+                  key={s.path}
+                  component={Link}
+                  to={s.path}
+                  onClick={handleMenuClose}
+                >
+                  {s.label}
+                </MenuItem>
+              ))}
+            </Menu>
+            {otherLinks.map((o) => (
+              <Button color="inherit" component={Link} to={o.path} key={o.path}>
+                {o.label}
+              </Button>
+            ))}
+          </>
+        )}
       </Toolbar>
     </AppBar>
   )

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -1,0 +1,49 @@
+import { Container, Typography, Box, Link as MuiLink } from '@mui/material'
+import Header from '../components/Header.jsx'
+import Footer from '../components/Footer.jsx'
+import { Link } from 'react-router-dom'
+
+const services = [
+  {
+    title: 'ソフトウェア開発・Web制作',
+    path: '/software',
+    desc: '社内業務の効率化を目的とした業務支援アプリケーションの開発から、オンライン申請、社内検索、帳票出力など日常業務を支えるシステムまで幅広く対応します。管理画面やホームページなどCMSや動的UIにも対応し、静的なHTML/CSSページからReactによるSPAまでトータルにサポートします。'
+  },
+  {
+    title: 'システム研究・開発',
+    path: '/research',
+    desc: '検索エンジン、AI連携、P2P分散ネットワークなど、先端技術の研究開発を行います。意味圧縮・全文検索・ノード構成の自動最適化といった応用分野にも注力し、実験的プロトタイピングにも柔軟に対応します。'
+  },
+  {
+    title: '動画配信・撮影・編集',
+    path: '/video',
+    desc: 'ライブ配信や録画収録の技術支援から、セミナー・講演会・社内研修など現場での撮影まで幅広くサポートします。三脚・カメラ・マイク・照明など基本的な機材を一通り所持しており、動画編集も内容によりご相談可能です。'
+  },
+  {
+    title: 'アプリ開発',
+    path: '/appdev',
+    desc: 'Webアプリからモバイルアプリまでマルチプラットフォームに対応します。要件定義から画面設計、バックエンド実装、クラウド連携まで一貫して支援し、PWA化や非同期処理、リアルタイムデータ表示など高度なニーズにも対応します。'
+  }
+]
+
+export default function Services() {
+  return (
+    <>
+      <Header />
+      <Container sx={{ py: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          サービス内容
+        </Typography>
+        {services.map((s) => (
+          <Box key={s.path} sx={{ mb: 4 }}>
+            <Typography variant="h5" component={Link} to={s.path} sx={{ textDecoration: 'none', color: 'primary.main' }}>
+              {s.title}
+            </Typography>
+            <Typography sx={{ mt: 1 }}>{s.desc}</Typography>
+          </Box>
+        ))}
+      </Container>
+      <Footer />
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add a Service overview page with longer descriptions
- introduce responsive header with dropdown menu for service links
- link the new page in the router

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c51f37aec8323b4112859c11f948e